### PR TITLE
Updated build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ sourceSets.main {
   }
   repositories {
     mavenLocal()
-    flatDir { dirs rootProject.file("tools") }
+    flatDir { dirs "tools" }
   }
   dependencies {
     jastadd2 name: "jastadd2"


### PR DESCRIPTION
Changed path the path used for the tools folder to be relative to current project directory instead of root project directory so that this project still builds even if it is used as a subproject in another root gradle project.